### PR TITLE
Added arb oracle addresses + new kovan deploy

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@halodao/xave-contract-addresses",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "List of Xave contract addresses across all chains",
   "repository": "https://github.com/HaloDAO/xave-contract-addresses",
   "author": "Xave Dev",

--- a/src/arb.ts
+++ b/src/arb.ts
@@ -19,7 +19,13 @@ const addresses: AddressCollection = {
     },
     proportionalLiquidity: ZERO_ADDRESS,
     assimilatorFactory: ZERO_ADDRESS,
-    oracles: {}
+    swapLibrary: ZERO_ADDRESS,
+    oracles: {
+      USDC: '0x50834F3163758fcC1Df9973b6e91f0F0F0434aD3',
+      fxPHP: '0xfF82AAF635645fD0bcc7b619C3F28004cDb58574',
+      XSGD: '0xF0d38324d1F86a176aC727A4b0c43c9F9d9c5EB1',
+      EURS: '0xA14d53bC1F1c0F31B4aA3BD109344E5009051a84'
+    }
   },
   tokens: {}
 }

--- a/src/arb.ts
+++ b/src/arb.ts
@@ -1,5 +1,15 @@
 import { AddressCollection, ZERO_ADDRESS } from './types'
 
+const tokens = {
+  USDC: '0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8',
+  EURS: '0xD22a58f79e9481D1a88e00c343885A588b34b68B',
+  fxPHP: '0x3d147cD9aC957B2a5F968dE9d1c6B9d0872286a0',
+  testUSDC: '0x9cFf4A10b6Fb163a4DF369AaFed9d95838222ca6', // Test mintable token
+  testFxPHP: '0x03612728266b82EF5dB751fbf15ea7F1370502eE', // Test mintable token
+  testXSGD: '0x6d934DcbA7F8e89713b4334147c03e76f30CE094', // Test mintable token
+  testEURS: '0xe42827D98C053b6e9c97E39BE8b611102E8c1805' // Test mintable token
+}
+
 const addresses: AddressCollection = {
   protocol: {
     XAV: ZERO_ADDRESS,
@@ -27,7 +37,7 @@ const addresses: AddressCollection = {
       EURS: '0xA14d53bC1F1c0F31B4aA3BD109344E5009051a84'
     }
   },
-  tokens: {}
+  tokens
 }
 
 export default addresses

--- a/src/arbTestnet.ts
+++ b/src/arbTestnet.ts
@@ -19,6 +19,7 @@ const addresses: AddressCollection = {
     },
     proportionalLiquidity: ZERO_ADDRESS,
     assimilatorFactory: ZERO_ADDRESS,
+    swapLibrary: ZERO_ADDRESS,
     oracles: {}
   },
   tokens: {}

--- a/src/kovan.ts
+++ b/src/kovan.ts
@@ -48,19 +48,26 @@ const addresses: AddressCollection = {
       enabled: [
         {
           assets: [tokens.fxPHP, tokens.USDC],
-          address: '0xe2094130f94CC23BDfe46FF0EF63A13899F4D708',
+          address: '0x7e3771D33E3731F790e6FCd8ca0a14B08d44a98d',
           poolId:
-            '0xe2094130f94cc23bdfe46ff0ef63a13899f4d7080002000000000000000007e9'
+            '0x7e3771d33e3731f790e6fcd8ca0a14b08d44a98d0002000000000000000008fd'
+        },
+        {
+          assets: [tokens.EURS, tokens.USDC],
+          address: '0xd98F5042648f304a150f4f9D054516e9125C8088',
+          poolId:
+            '0xd98f5042648f304a150f4f9d054516e9125c80880002000000000000000008fe'
         }
       ],
       disabled: []
     },
-    proportionalLiquidity: '0x0dEf4438AdEcedE57A861b0964c84a50C68eEaDe',
-    assimilatorFactory: '0x4c13F1E2397f083bbaCCB4E53325d5389845BE2e',
+    proportionalLiquidity: '0x000f891aD773aBE5548446b4528161563113566a',
+    assimilatorFactory: '0x5fF15655C1E9de73eA63465F2BCA0D1636318240',
+    swapLibrary: '0xc9A5DA4a6BD896dee1eaB92C75C41101e835dF2A',
     oracles: {
       USDC: '0x9211c6b3BF41A10F78539810Cf5c64e1BB78Ec60',
       fxPHP: '0x84fdC8dD500F29902C99c928AF2A91970E7432b6',
-      XSGD: '0x8CE3cAc0E6635ce04783709ca3CC4F5fc5304299',
+      XSGD: '0xa5FC4B3757Ce2533087de51752D12d908E48FEEF', // Mock
       EURS: '0x0c15Ab9A0DB086e062194c273CC79f41597Bbf13'
     }
   },

--- a/src/mainnet.ts
+++ b/src/mainnet.ts
@@ -40,6 +40,7 @@ const addresses: AddressCollection = {
     },
     proportionalLiquidity: ZERO_ADDRESS,
     assimilatorFactory: ZERO_ADDRESS,
+    swapLibrary: ZERO_ADDRESS,
     oracles: {}
   },
   tokens,

--- a/src/matic.ts
+++ b/src/matic.ts
@@ -24,6 +24,7 @@ const addresses: AddressCollection = {
     },
     proportionalLiquidity: ZERO_ADDRESS,
     assimilatorFactory: ZERO_ADDRESS,
+    swapLibrary: ZERO_ADDRESS,
     oracles: {
       USDC: '0xfE4A8cc5b5B2366C1B58Bea3858e81843581b2F7',
       fxPHP: '0x218231089Bebb2A31970c3b77E96eCfb3BA006D1',

--- a/src/matic.ts
+++ b/src/matic.ts
@@ -1,8 +1,8 @@
 import { AddressCollection, ZERO_ADDRESS } from './types'
 
 const tokens = {
-  fakeUSDC: '0xd92295aDCE5B6961853394Ad05fb4670012D8c60',
-  fakeFxPHP: '0xe1Ca353a88a8822ed95293a7E76bd20eEA2ff662'
+  testUSDC: '0xd92295aDCE5B6961853394Ad05fb4670012D8c60', // Test mintable token
+  testFxPHP: '0xe1Ca353a88a8822ed95293a7E76bd20eEA2ff662' // Test mintable token
 }
 
 const addresses: AddressCollection = {

--- a/src/rinkeby.ts
+++ b/src/rinkeby.ts
@@ -28,6 +28,7 @@ const addresses: AddressCollection = {
     },
     proportionalLiquidity: ZERO_ADDRESS,
     assimilatorFactory: ZERO_ADDRESS,
+    swapLibrary: ZERO_ADDRESS,
     oracles: {}
   },
   tokens

--- a/src/types.ts
+++ b/src/types.ts
@@ -48,8 +48,10 @@ export type AddressCollection = {
     fxAUD?: string
     UST?: string
     CHF?: string
-    fakeUSDC?: string
-    fakeFxPHP?: string
+    testUSDC?: string
+    testFxPHP?: string
+    testXSGD?: string
+    testEURS?: string
   }
   lendingMarket?: {
     protocol: {

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,6 +25,7 @@ export type AddressCollection = {
     }
     proportionalLiquidity: string
     assimilatorFactory: string
+    swapLibrary: string
     oracles: {
       USDC?: string
       fxPHP?: string


### PR DESCRIPTION
- Added oracles addresses for arbitrum mainnet
  - also deployed a new XSGD oracle for kovan (previous one doesn't exists)
- New kovan deploy for fxPHP:USDC & EURS:USDC pools

For reviewers:
Need another head to please double check the oracle addresses